### PR TITLE
fix:Daily Challenge Link Not Redirecting on Click

### DIFF
--- a/popup/src/components/Daily.tsx
+++ b/popup/src/components/Daily.tsx
@@ -12,6 +12,7 @@ export default function Daily({ data }: { data: DailyProblemI }) {
             <p className="font-medium text-xs text-lp-grey">Daily
               Problem</p>
             <a
+              target="_blank"
               href={`https://leetcode.com${data.link}`}
               rel="noreferrer"
               className="text-sm font-medium underline transition-colors duration-200 hover:text-blue-500"


### PR DESCRIPTION
Resolved an issue where clicking the daily challenge link did not navigate to the intended URL. The problem was fixed by adding `target="_blank"` to ensure the link opens correctly in a new tab.
